### PR TITLE
Fix: Remove unintended background from MasonryGrid columns

### DIFF
--- a/src/components/karya/MasonryGrid.tsx
+++ b/src/components/karya/MasonryGrid.tsx
@@ -39,7 +39,7 @@ export const MasonryGrid: React.FC<MasonryGridProps> = ({
     <Masonry
       breakpointCols={breakpointColumnsObj}
       className="flex w-auto -ml-4 my-masonry-grid"
-      columnClassName="pl-4 bg-background my-masonry-grid_column"
+      columnClassName="pl-4 bg-transparent my-masonry-grid_column"
     >
       {items.map((item) => (
         <motion.div


### PR DESCRIPTION
The MasonryGrid columns (`my-masonry-grid_column`) were previously using the `bg-background` utility class. This was causing an unintended background color to appear on the grid, making it seem like the entire grid was inside a colored container.

This commit changes the `columnClassName` in `MasonryGrid.tsx` to use `bg-transparent` instead of `bg-background` for the `my-masonry-grid_column` class. This ensures that the columns have a transparent background, allowing the main page background to show through, as intended by the design.

The parent container `.my-masonry-grid` was also checked and confirmed to not have any conflicting background styles.