### PR TITLE
Fix: Adjust FloatingNav sticky position to avoid header overlap

### DIFF
--- a/src/components/karya/FloatingNav.tsx
+++ b/src/components/karya/FloatingNav.tsx
@@ -11,6 +11,7 @@ interface FloatingNavProps {
 const FloatingNav: React.FC<FloatingNavProps> = ({ toggleFilters, showFilters }) => {
   const [scrolled, setScrolled] = useState(false);
   const [showBackToTop, setShowBackToTop] = useState(false);
+  const [headerHeight, setHeaderHeight] = useState(0);
   
   // Optimized scroll handler with throttling
   useEffect(() => {
@@ -30,6 +31,13 @@ const FloatingNav: React.FC<FloatingNavProps> = ({ toggleFilters, showFilters })
     
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    const header = document.querySelector('header.fixed') as HTMLElement;
+    if (header) {
+      setHeaderHeight(header.offsetHeight);
+    }
   }, []);
   
   const scrollToTop = () => {
@@ -51,11 +59,14 @@ const FloatingNav: React.FC<FloatingNavProps> = ({ toggleFilters, showFilters })
           duration: 0.4,
           ease: "easeOut"
         }}
-        className={`fixed top-0 left-0 right-0 z-40 py-4 px-6 flex items-center justify-between transition-all duration-300 ${
+        style={{
+          top: scrolled ? `${headerHeight}px` : '0px',
+        }}
+        className={`fixed left-0 right-0 z-40 py-4 px-6 flex items-center justify-between transition-all duration-300 ${
           scrolled 
             ? "bg-background/95 backdrop-blur-md shadow-lg shadow-black/20 border-b border-border/30" 
             : "bg-transparent"
-        }`}
+        } ${scrolled ? "" : "top-0"}`} // Conditionally add top-0 when not scrolled
       >
         <motion.div 
           className="flex items-center space-x-3"


### PR DESCRIPTION
The FloatingNav component, when becoming sticky on scroll, was overlapping the main site header. This was due to its `top` position being set to `0` without considering the height of the main header.

This commit addresses the issue by:
1.  Dynamically calculating the `offsetHeight` of the main site header (`header.fixed` in `PageLayout.tsx`) when the `FloatingNav` component mounts.
2.  Storing this height in a state variable (`headerHeight`).
3.  When `FloatingNav` becomes sticky (based on scroll position), its inline `top` style is now set to this `headerHeight`, positioning it directly below the main header.
4.  The `top-0` Tailwind CSS class is now conditionally applied to `FloatingNav` only when it's not in its sticky state, preventing conflicts with the dynamic inline `top` style.

This ensures that the `FloatingNav` correctly appears below the main header when sticky, providing a seamless user experience without visual overlap.