### PR TITLE
Fix: Ensure newlines in announcement content render as line breaks

### DIFF
--- a/src/components/announcement/AnnouncementDetail.tsx
+++ b/src/components/announcement/AnnouncementDetail.tsx
@@ -181,11 +181,13 @@ export const AnnouncementDetail: React.FC<AnnouncementDetailProps> = ({ announce
       }
       
       // Regular paragraph with better styling
+      const lines = paragraph.split('\n');
       return (
         <div key={idx} className="bg-white/3 rounded-lg p-4 border border-white/10">
-          <p className="text-sm sm:text-base leading-relaxed">
-            {paragraph}
-          </p>
+          <p
+            className="text-sm sm:text-base leading-relaxed"
+            dangerouslySetInnerHTML={{ __html: lines.join('<br />') }}
+          />
         </div>
       );
     });


### PR DESCRIPTION
I modified the `parseContent` function in `AnnouncementDetail.tsx` to correctly render newline characters (`\n`) as line breaks (`<br />`) within announcement content paragraphs.

Previously, single newlines were not being rendered, causing text that should have been on separate lines to appear on the same line. This change ensures that the intended formatting of announcement content, including both paragraph breaks (from `\n\n`) and line breaks (from `\n`), is accurately displayed to you.

The solution involves splitting paragraphs by `\n` and rejoining them with `<br />` tags, utilizing `dangerouslySetInnerHTML` for rendering the HTML. Existing markdown-like list and header parsing logic remains unaffected.