### PR TITLE
Fix: Resolve critical React crash and newline rendering issues

### DIFF
--- a/src/components/announcement/AnnouncementCard.tsx
+++ b/src/components/announcement/AnnouncementCard.tsx
@@ -239,9 +239,13 @@ export const AnnouncementCard: React.FC<AnnouncementCardProps> = ({
             {announcement.title}
           </motion.h3>
           
-          <p className={`line-clamp-3 text-sm mb-4 leading-relaxed whitespace-pre-line
-            ${isGerakan27April ? 'text-red-100/80' : 'text-foreground/75'}`}>
-            {announcement.content.substring(0, isMobile ? 100 : 120)}...
+          <p className={`text-sm mb-4 leading-relaxed ${isGerakan27April ? 'text-red-100/80' : 'text-foreground/75'}`}>
+            {(announcement.content.substring(0, isMobile ? 100 : 120) + "...").split('\n').map((line, index) => (
+              <React.Fragment key={index}>
+                {line}
+                <br />
+              </React.Fragment>
+            ))}
           </p>
         </div>
         

--- a/src/components/announcement/AnnouncementDetailModal.tsx
+++ b/src/components/announcement/AnnouncementDetailModal.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Calendar, X } from "lucide-react";
 import { format } from "date-fns";
 import { Announcement } from "@/models/Announcement";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 
@@ -105,7 +105,7 @@ export const AnnouncementDetailModal: React.FC<AnnouncementDetailModalProps> = (
                 
                 {/* Content */}
                 {/* The `prose` classes might add their own margins, so `my-2` and `my-4` might need adjustment if there's too much space */}
-                <Dialog.Description asChild>
+                <DialogDescription asChild>
                   <div className="prose prose-lg max-w-none"> {/* Removed space-y-6 from here to let parseContent handle spacing */}
                     {announcement.content.split('\n').map((line, index) => (
                       // Render each line. Using a simple text line with a line break,


### PR DESCRIPTION
This commit addresses two critical issues:

1.  **Fatal React Error #130 on Announcement Click:**
    - The application was crashing when you clicked an announcement card due to an "Element type is invalid" error (Minified React error #130).
    - This was caused by an incorrect import and usage of the `DialogDescription` component within `AnnouncementDetailModal.tsx`.
    - The fix involves correcting the import to be a named import: `import { Dialog, DialogContent, DialogDescription } from "@/components/ui/dialog";` and updating its usage in JSX from `<Dialog.Description>` to `<DialogDescription>`.

2.  **Newline Characters Not Rendering on Announcement Cards:**
    - Newline characters (`\n`) in the announcement summary (content) on `AnnouncementCard.tsx` were being displayed as literal text.
    - This is resolved by implementing a manual string splitting technique. The `announcement.content` is truncated, then split by `\n`, and each resulting line is rendered within a `React.Fragment` followed by a `<br />` tag.
    - Conflicting CSS classes (`line-clamp-3`, `whitespace-pre-line`) were removed from the affected element.

Newline characters in the `AnnouncementDetailModal.tsx` were previously addressed and should continue to function as expected. These changes ensure application stability and correct content rendering.