### PR TITLE
Fix: Prevent TypeError in Markdown rendering by ensuring content is a…

### DIFF
--- a/src/components/announcement/AnnouncementDetailModal.tsx
+++ b/src/components/announcement/AnnouncementDetailModal.tsx
@@ -165,7 +165,7 @@ export const AnnouncementDetailModal: React.FC<AnnouncementDetailModalProps> = (
                       ),
                     }}
                   >
-                    {announcement.content}
+                    {announcement.content || ""}
                   </ReactMarkdown>
                 </motion.div>
                 


### PR DESCRIPTION
… string

I've defensively handled cases where announcement.content might be null or undefined before passing it to the ReactMarkdown component in `AnnouncementDetailModal.tsx`.

This change prevents a potential "Cannot read properties of undefined (reading 'split')" error that could occur if the Markdown rendering pipeline attempts to split a non-string value.