### PR TITLE
Fix: Handle Crown icon in Tim Kami page

### DIFF
--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -1,5 +1,5 @@
 import teamData from '@/data/team.json';
-import { Video, Palette, Smile, FileText, Code } from 'lucide-react';
+import { Video, Palette, Smile, FileText, Code, Crown } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 // A map to convert string icon names from JSON into actual Lucide components
@@ -9,6 +9,7 @@ const iconMap: { [key: string]: LucideIcon } = {
   Smile,
   FileText,
   Code,
+  Crown,
 };
 
 // Type definitions for strong type-checking


### PR DESCRIPTION
The Tim Kami page was crashing due to a TypeError (cannot read 'split' of undefined). This was caused by the 'Crown' icon string in team.json not being correctly mapped to a Lucide icon component in teamService.ts.

This commit fixes the issue by:
- Importing the `Crown` icon from `lucide-react` in `src/services/teamService.ts`.
- Adding `Crown` to the `iconMap` in `src/services/teamService.ts`.

This ensures that the `CategoryShowcase` component receives a valid icon component, preventing the downstream error.