### PR TITLE
Fix: Resolve overlay, scrolling, and close button issues in Karya det…

### DIFF
--- a/src/components/karya/detail/KaryaInfoPanel.tsx
+++ b/src/components/karya/detail/KaryaInfoPanel.tsx
@@ -113,9 +113,7 @@ export const KaryaInfoPanel = ({ karya }: KaryaInfoPanelProps) => {
             <ScrollArea className={`${
               isDescriptionExpanded ? 'h-full' : 'h-32'
             }`}>
-              <div className={`transition-all duration-300 ${
-                isDescriptionExpanded ? 'max-h-none' : 'max-h-32'
-              } overflow-hidden relative`}>
+              <div className={`transition-all duration-300 relative`}>
                 <p className="text-foreground/90 leading-relaxed font-sans text-sm whitespace-pre-wrap break-words pr-4">
                   {karya.description}
                 </p>

--- a/src/components/karya/detail/KaryaMediaViewer.tsx
+++ b/src/components/karya/detail/KaryaMediaViewer.tsx
@@ -133,7 +133,7 @@ export const KaryaMediaViewer = ({ karya, onClose, showInfoPanel, toggleInfoPane
   };
 
   return (
-    <div className={cn("relative bg-black/50 flex-grow h-full w-full", isText && "md:h-auto")}>
+    <div className={cn("relative bg-black/50 flex-grow h-full w-full")}>
       {isText ? renderTextContent() : renderMediaContent()}
       
       {/* Floating control buttons */}


### PR DESCRIPTION
…ailed view

This commit addresses persistent layout problems in the Karya detailed view, particularly for 'Karya Tulis' with long content, which caused:
- Text from one panel to overlay another.
- Scrolling to fail in the description panel.
- The main close button ('X') to become inaccessible.

Revised Changes:

1.  **`KaryaMediaViewer.tsx`:**
    - I removed the `md:h-auto` class from the root element when displaying text content ('Karya Tulis'). The component will now consistently use `h-full`, ensuring it respects the height allocated by its parent flex container in `KaryaDetailDialog.tsx`. This prevents the viewer from becoming excessively tall and disrupting the overall dialog layout. Internal scrolling via `ScrollArea` will handle long text.

2.  **`KaryaInfoPanel.tsx`:**
    - I removed `overflow-hidden` and dynamic `max-h-xx` classes from the `div` immediately inside the `ScrollArea` used for the description. This allows the `ScrollArea` component to correctly manage its content's overflow and provide scrolling when the description text is long.

These changes ensure better adherence to layout constraints and standard behavior for scrollable components, significantly improving the stability and usability of the Karya detailed view. The previous fix for URL rendering as text is retained.